### PR TITLE
Added Version and AssemblyVersion strings

### DIFF
--- a/Caterpillar.GH/Caterpillar.GHInfo.cs
+++ b/Caterpillar.GH/Caterpillar.GHInfo.cs
@@ -36,6 +36,10 @@ namespace Caterpillar.GH
             return new Guid("ab9be5da-5942-4909-8f30-bf436448e1ff");
         }
     }
+    
+    public override string Version => "1.0.0";
+
+    public override string AssemblyVersion => this.Version;
 
     public override string AuthorName
     {


### PR DESCRIPTION
@interopxyz 
I've overridden the `Version` and `AssemblyVersion` string properties in the `GH_AssemblyInfo` inheriting class.
This has been done to allow us to support Caterpillar on the [ShapeDiver](https://www.shapediver.com/) platform.
A copy of the plugin will be installed and run on our cloud Grasshopper instances. Please let me know if this is acceptable for you.
Note: For future releases, please remember to increment this version string before building and publishing, so that we can continue supporting those versions as well.
Thanks!